### PR TITLE
Replace internal package repo. Remove extra step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ E. Run your app
 
 * Browse to the cloned sample application
 * Run `npm install`
-* Run `npm build`
 * Run `npm start`
 
 You should get something like this:

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,8 +127,8 @@
     },
     "abbrev": {
       "version": "1.1.1",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -3117,7 +3117,7 @@
     },
     "ignore-by-default": {
       "version": "1.0.1",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
     },
@@ -4829,8 +4829,8 @@
     },
     "nodemon": {
       "version": "1.18.11",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/nodemon/-/nodemon-1.18.11.tgz",
-      "integrity": "sha1-2DarZjd255lVcLlj2lv8gH5T9rg=",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.11.tgz",
+      "integrity": "sha512-KdN3tm1zkarlqNo4+W9raU3ihM4H15MVMSE/f9rYDZmFgDHAfAJsomYrHhApAkuUemYjFyEeXlpCOQ2v5gtBEw==",
       "dev": true,
       "requires": {
         "chokidar": "^2.1.5",
@@ -4847,14 +4847,14 @@
       "dependencies": {
         "array-unique": {
           "version": "0.3.2",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/array-unique/-/array-unique-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
           "dev": true
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -4871,8 +4871,8 @@
         },
         "chokidar": {
           "version": "2.1.5",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/chokidar/-/chokidar-2.1.5.tgz",
-          "integrity": "sha1-CuhDTZYigaX1bHKGnnnLbZ2GrU0=",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
+          "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
           "dev": true,
           "requires": {
             "anymatch": "^2.0.0",
@@ -4891,7 +4891,7 @@
         },
         "extend-shallow": {
           "version": "2.0.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
@@ -4900,7 +4900,7 @@
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/fill-range/-/fill-range-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
@@ -4912,7 +4912,7 @@
         },
         "glob-parent": {
           "version": "3.1.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/glob-parent/-/glob-parent-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
@@ -4922,7 +4922,7 @@
           "dependencies": {
             "is-glob": {
               "version": "3.1.0",
-              "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-glob/-/is-glob-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
@@ -4933,14 +4933,14 @@
         },
         "is-extglob": {
           "version": "2.1.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-extglob/-/is-extglob-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
           "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
           "dev": true
         },
         "is-glob": {
           "version": "4.0.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-glob/-/is-glob-4.0.1.tgz",
-          "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
@@ -4948,7 +4948,7 @@
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/is-number/-/is-number-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
@@ -4957,21 +4957,21 @@
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/isobject/-/isobject-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         },
         "normalize-path": {
           "version": "3.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
           "dev": true
         }
       }
     },
     "nopt": {
       "version": "1.0.10",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/nopt/-/nopt-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
@@ -5276,7 +5276,7 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
@@ -5468,8 +5468,8 @@
     },
     "pstree.remy": {
       "version": "1.1.6",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/pstree.remy/-/pstree.remy-1.1.6.tgz",
-      "integrity": "sha1-c6VarZ4tlYFJJxMfv03Bti0ln0c=",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
+      "integrity": "sha512-NdF35+QsqD7EgNEI5mkI/X+UwaxVEbQaz9f4IooEmMUv6ZPmlTQYGjBPJGgrlzNdjSvIy4MWMg6Q6vCgBO2K+w==",
       "dev": true
     },
     "pug": {
@@ -7212,8 +7212,8 @@
     },
     "touch": {
       "version": "3.1.0",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
         "nopt": "~1.0.10"
@@ -7554,7 +7554,7 @@
     },
     "undefsafe": {
       "version": "2.0.2",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/undefsafe/-/undefsafe-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.2.tgz",
       "integrity": "sha1-Il9rngM3Zj4Njnz9aG/Cg2zKznY=",
       "dev": true,
       "requires": {
@@ -7563,8 +7563,8 @@
       "dependencies": {
         "debug": {
           "version": "2.6.9",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -7572,7 +7572,7 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
         }
@@ -7685,8 +7685,8 @@
     },
     "upath": {
       "version": "1.1.2",
-      "resolved": "https://repo.dev.wixpress.com/artifactory/api/npm/npm-repos/upath/-/upath-1.1.2.tgz",
-      "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
     "update-notifier": {


### PR DESCRIPTION
Replace internal package references with references to identical packages in standard public registries, allowing outside developers to build the sample successfully. Also remove an extra build step from README.

Closes #18 